### PR TITLE
Implement realtime lobby and table updates over WebSockets

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import RootNavigator from './src/navigation/RootNavigator';
 import { AuthProvider } from './src/auth/AuthContext';
+import { RealtimeProvider } from './src/realtime/RealtimeProvider';
 
 const theme = { ...DefaultTheme, colors: { ...DefaultTheme.colors, background: '#0b0f14' } };
 
@@ -17,7 +18,9 @@ export default function App() {
   return (
     <NavigationContainer theme={theme}>
       <AuthProvider>
-        <RootNavigator />
+        <RealtimeProvider>
+          <RootNavigator />
+        </RealtimeProvider>
       </AuthProvider>
     </NavigationContainer>
   );

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This is a new [**React Native**](https://reactnative.dev) project, bootstrapped 
 
 > **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
 
+## Realtime development server
+
+The mobile lobby and table views now connect to a lightweight Node.js WebSocket service that tracks mock tables and broadcasts join/leave messages. Run it alongside Metro with:
+
+```sh
+cd server
+npm run dev
+```
+
+The client expects the server on `ws://localhost:4000` (or `ws://10.0.2.2:4000` for Android emulators). When both the app and server are running you'll see live table counts in the lobby and realtime join/leave activity inside each table screen.
+
 ## Step 1: Start Metro
 
 First, you will need to run **Metro**, the JavaScript build tool for React Native.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
-import { Server } from 'socket.io';
+import { WebSocketServer, WebSocket } from 'ws';
 
 const PORT = Number(process.env.PORT || 4000);
 
@@ -10,33 +10,162 @@ app.use(cors());
 app.get('/', (_req, res) => res.send('Teen Patti realtime server OK'));
 
 const httpServer = http.createServer(app);
-const io = new Server(httpServer, {
-  cors: { origin: '*', methods: ['GET', 'POST'] }, // dev only
-});
+const wss = new WebSocketServer({ server: httpServer });
 
-io.on('connection', (socket) => {
-  console.log('client connected', socket.id);
+type Table = { id: string; minBet: number };
+type TableSummary = Table & { players: number };
 
-  // simple echo test
-  socket.on('ping:echo', (msg: string, cb?: (reply: string) => void) => {
-    const reply = `echo:${msg}`;
-    cb?.(reply);
-    socket.emit('pong:echo', reply);
+type ClientMessage =
+  | { type: 'lobby:subscribe' }
+  | { type: 'lobby:unsubscribe' }
+  | { type: 'table:join'; tableId: string; displayName?: string }
+  | { type: 'table:leave'; tableId: string };
+
+type Session = {
+  id: string;
+  displayName?: string;
+  tableId?: string;
+};
+
+const tables: Table[] = [
+  { id: 't1', minBet: 10 },
+  { id: 't2', minBet: 50 },
+  { id: 't3', minBet: 100 },
+];
+
+const sessions = new Map<WebSocket, Session>();
+const tableMembers = new Map<string, Set<WebSocket>>();
+
+for (const table of tables) {
+  tableMembers.set(table.id, new Set());
+}
+
+function generateSessionId() {
+  return 'ws_' + Math.random().toString(36).slice(2, 10);
+}
+
+function buildLobbySummary(): TableSummary[] {
+  return tables.map((table) => ({
+    ...table,
+    players: tableMembers.get(table.id)?.size ?? 0,
+  }));
+}
+
+function send(ws: WebSocket, data: unknown) {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(data));
+  }
+}
+
+function broadcastLobby() {
+  const payload = JSON.stringify({ type: 'lobby:data', tables: buildLobbySummary() });
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(payload);
+    }
+  }
+}
+
+function notifyTable(tableId: string, message: string, exclude?: WebSocket) {
+  const payload = JSON.stringify({ type: 'table:system', tableId, message });
+  const members = tableMembers.get(tableId);
+  if (!members) return;
+  for (const client of members) {
+    if (client.readyState === WebSocket.OPEN && client !== exclude) {
+      client.send(payload);
+    }
+  }
+}
+
+function leaveTable(ws: WebSocket, options?: { silent?: boolean }) {
+  const session = sessions.get(ws);
+  if (!session?.tableId) return;
+  const { tableId } = session;
+  const members = tableMembers.get(tableId);
+  members?.delete(ws);
+
+  const displayName = session.displayName ?? `Player ${session.id.slice(-4)}`;
+  notifyTable(tableId, `${displayName} left the table`, ws);
+
+  if (!options?.silent) {
+    send(ws, { type: 'table:system', tableId, message: `You left table ${tableId}` });
+  }
+
+  session.tableId = undefined;
+  broadcastLobby();
+}
+
+function joinTable(ws: WebSocket, tableId: string, displayName?: string) {
+  if (!tableMembers.has(tableId)) {
+    send(ws, { type: 'error', message: 'Unknown table' });
+    return;
+  }
+
+  const session = sessions.get(ws);
+  if (!session) return;
+
+  if (session.tableId === tableId) {
+    return;
+  }
+
+  if (session.tableId) {
+    leaveTable(ws, { silent: true });
+  }
+
+  session.tableId = tableId;
+  session.displayName = displayName?.trim() || session.displayName || `Player ${session.id.slice(-4)}`;
+
+  const members = tableMembers.get(tableId);
+  if (!members) return;
+
+  members.add(ws);
+  send(ws, { type: 'table:system', tableId, message: `You joined table ${tableId}` });
+  notifyTable(tableId, `${session.displayName} joined the table`, ws);
+  broadcastLobby();
+}
+
+wss.on('connection', (ws) => {
+  const session: Session = { id: generateSessionId() };
+  sessions.set(ws, session);
+
+  send(ws, { type: 'lobby:data', tables: buildLobbySummary() });
+
+  ws.on('message', (raw) => {
+    let msg: ClientMessage;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch (err) {
+      console.warn('Failed to parse message', err);
+      return;
+    }
+
+    switch (msg.type) {
+      case 'lobby:subscribe':
+        send(ws, { type: 'lobby:data', tables: buildLobbySummary() });
+        break;
+      case 'lobby:unsubscribe':
+        // no-op for now
+        break;
+      case 'table:join':
+        joinTable(ws, msg.tableId, msg.displayName);
+        break;
+      case 'table:leave':
+        if (sessions.get(ws)?.tableId === msg.tableId) {
+          leaveTable(ws);
+        }
+        break;
+      default:
+        send(ws, { type: 'error', message: 'Unknown event' });
+    }
   });
 
-  // join/leave a table room (we'll use this in TableScreen soon)
-  socket.on('table:join', ({ tableId }: { tableId: string }) => {
-    socket.join(`table:${tableId}`);
-    socket.to(`table:${tableId}`).emit('system', `player ${socket.id} joined ${tableId}`);
+  ws.on('close', () => {
+    leaveTable(ws, { silent: true });
+    sessions.delete(ws);
   });
 
-  socket.on('table:leave', ({ tableId }: { tableId: string }) => {
-    socket.leave(`table:${tableId}`);
-    socket.to(`table:${tableId}`).emit('system', `player ${socket.id} left ${tableId}`);
-  });
-
-  socket.on('disconnect', (reason) => {
-    console.log('client disconnected', socket.id, reason);
+  ws.on('error', (err) => {
+    console.error('WebSocket error', err);
   });
 });
 

--- a/src/realtime/RealtimeProvider.tsx
+++ b/src/realtime/RealtimeProvider.tsx
@@ -1,0 +1,166 @@
+import React, {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Platform } from 'react-native';
+
+export type TableSummary = { id: string; minBet: number; players: number };
+
+export type ServerMessage =
+  | { type: 'lobby:data'; tables: TableSummary[] }
+  | { type: 'table:system'; tableId: string; message: string }
+  | { type: 'error'; message: string };
+
+export type ClientMessage =
+  | { type: 'lobby:subscribe' }
+  | { type: 'lobby:unsubscribe' }
+  | { type: 'table:join'; tableId: string; displayName?: string }
+  | { type: 'table:leave'; tableId: string };
+
+type RealtimeStatus = 'connecting' | 'open' | 'closed';
+
+type RealtimeContextValue = {
+  status: RealtimeStatus;
+  send: (message: ClientMessage) => void;
+  subscribe: <T extends ServerMessage['type']>(
+    type: T,
+    handler: (payload: Extract<ServerMessage, { type: T }>) => void,
+  ) => () => void;
+};
+
+const DEFAULT_VALUE: RealtimeContextValue = {
+  status: 'closed',
+  send: () => {},
+  subscribe: () => () => {},
+};
+
+const SERVER_URL = Platform.select({
+  android: 'ws://10.0.2.2:4000',
+  ios: 'ws://localhost:4000',
+  default: 'ws://localhost:4000',
+});
+
+const RealtimeContext = createContext<RealtimeContextValue>(DEFAULT_VALUE);
+
+export function RealtimeProvider({ children }: PropsWithChildren) {
+  const [status, setStatus] = useState<RealtimeStatus>('connecting');
+  const socketRef = useRef<WebSocket | null>(null);
+  const listenersRef = useRef<
+    Map<ServerMessage['type'], Set<(payload: ServerMessage) => void>>
+  >(new Map());
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttempts = useRef(0);
+  const closingRef = useRef(false);
+
+  useEffect(() => {
+    function clearTimer() {
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current);
+        reconnectTimer.current = null;
+      }
+    }
+
+    const isSupported = typeof globalThis.WebSocket !== 'undefined';
+    if (!isSupported) {
+      setStatus('closed');
+      return () => {};
+    }
+
+    const resolvedUrl = SERVER_URL ?? 'ws://localhost:4000';
+
+    function connect() {
+      clearTimer();
+      setStatus('connecting');
+      const socket = new globalThis.WebSocket(resolvedUrl);
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        reconnectAttempts.current = 0;
+        setStatus('open');
+      };
+
+      socket.onclose = () => {
+        socketRef.current = null;
+        if (closingRef.current) return;
+        setStatus('closed');
+        reconnectAttempts.current += 1;
+        const delay = Math.min(5000, 500 * reconnectAttempts.current);
+        reconnectTimer.current = setTimeout(connect, delay);
+      };
+
+      socket.onerror = () => {
+        setStatus('closed');
+      };
+
+      socket.onmessage = (event) => {
+        let data: ServerMessage;
+        try {
+          data = JSON.parse(event.data);
+        } catch (err) {
+          console.warn('Failed to parse realtime message', err);
+          return;
+        }
+
+        if (!data || typeof data !== 'object' || !('type' in data)) {
+          return;
+        }
+
+        const handlers = listenersRef.current.get((data as ServerMessage).type);
+        if (!handlers?.size) return;
+        handlers.forEach((handler) => {
+          handler(data);
+        });
+      };
+    }
+
+    connect();
+
+    return () => {
+      closingRef.current = true;
+      clearTimer();
+      socketRef.current?.close();
+      socketRef.current = null;
+    };
+  }, []);
+
+  const send = useCallback((message: ClientMessage) => {
+    const socket = socketRef.current;
+    if (socket && socket.readyState === 1) {
+      socket.send(JSON.stringify(message));
+    }
+  }, []);
+
+  const subscribe = useCallback<RealtimeContextValue['subscribe']>((type, handler) => {
+    let listeners = listenersRef.current.get(type);
+    if (!listeners) {
+      listeners = new Set();
+      listenersRef.current.set(type, listeners);
+    }
+    const wrapped = handler as unknown as (payload: ServerMessage) => void;
+    listeners.add(wrapped);
+
+    return () => {
+      listeners?.delete(wrapped);
+      if (listeners && listeners.size === 0) {
+        listenersRef.current.delete(type);
+      }
+    };
+  }, []);
+
+  const value = useMemo<RealtimeContextValue>(
+    () => ({ status, send, subscribe }),
+    [send, status, subscribe],
+  );
+
+  return <RealtimeContext.Provider value={value}>{children}</RealtimeContext.Provider>;
+}
+
+export function useRealtime() {
+  return useContext(RealtimeContext);
+}

--- a/src/screens/LobbyScreen.tsx
+++ b/src/screens/LobbyScreen.tsx
@@ -1,22 +1,63 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/RootNavigator';
+import { useRealtime, type TableSummary } from '../realtime/RealtimeProvider';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MainTabs'>;
 
-const mockTables = [
-  { id: 't1', minBet: 10, players: 2 },
-  { id: 't2', minBet: 50, players: 4 },
-  { id: 't3', minBet: 100, players: 1 },
-];
-
 export default function LobbyScreen({ navigation }: Props) {
+  const { status, send, subscribe } = useRealtime();
+  const [tables, setTables] = useState<TableSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribeData = subscribe('lobby:data', (payload) => {
+      setTables(payload.tables);
+      setError(null);
+    });
+    const unsubscribeError = subscribe('error', (payload) => {
+      setError(payload.message);
+    });
+
+    return () => {
+      unsubscribeData();
+      unsubscribeError();
+    };
+  }, [subscribe]);
+
+  useEffect(() => {
+    if (status === 'open') {
+      send({ type: 'lobby:subscribe' });
+    }
+
+    return () => {
+      if (status === 'open') {
+        send({ type: 'lobby:unsubscribe' });
+      }
+    };
+  }, [send, status]);
+
+  const connectionLabel = useMemo(() => {
+    switch (status) {
+      case 'open':
+        return 'Connected';
+      case 'connecting':
+        return 'Connecting…';
+      default:
+        return 'Reconnecting…';
+    }
+  }, [status]);
+
   return (
     <View style={s.wrap}>
-      <Text style={s.title}>Lobby</Text>
+      <View style={s.headerRow}>
+        <Text style={s.title}>Lobby</Text>
+        <Text style={[s.status, status === 'open' ? s.statusOk : s.statusWarn]}>{connectionLabel}</Text>
+      </View>
+      {error ? <Text style={s.error}>{error}</Text> : null}
       <FlatList
-        data={mockTables}
+        data={tables}
         keyExtractor={(i) => i.id}
         renderItem={({ item }) => (
           <Pressable
@@ -29,6 +70,13 @@ export default function LobbyScreen({ navigation }: Props) {
             </Text>
           </Pressable>
         )}
+        ListEmptyComponent={
+          <View style={s.empty}>
+            <Text style={s.emptyText}>
+              {status === 'open' ? 'No tables available yet.' : 'Waiting for realtime lobby…'}
+            </Text>
+          </View>
+        }
       />
     </View>
   );
@@ -36,8 +84,20 @@ export default function LobbyScreen({ navigation }: Props) {
 
 const s = StyleSheet.create({
   wrap: { flex: 1, backgroundColor: '#0b0f14', padding: 16 },
-  title: { color: 'white', fontSize: 24, fontWeight: '700', marginBottom: 12 },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  title: { color: 'white', fontSize: 24, fontWeight: '700' },
+  status: { fontSize: 13, color: '#9fb3c8' },
+  statusOk: { color: '#4ce3b4' },
+  statusWarn: { color: '#f0a75e' },
+  error: { color: '#ff6f6f', marginBottom: 8 },
   card: { backgroundColor: '#121922', borderRadius: 14, padding: 16, marginBottom: 12 },
   cardTitle: { color: 'white', fontSize: 18, fontWeight: '600' },
   cardSub: { color: '#9fb3c8', marginTop: 4 },
+  empty: { paddingVertical: 40, alignItems: 'center' },
+  emptyText: { color: '#9fb3c8' },
 });

--- a/src/screens/TableScreen.tsx
+++ b/src/screens/TableScreen.tsx
@@ -1,17 +1,81 @@
-import React from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, FlatList } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/RootNavigator';
+import { useRealtime } from '../realtime/RealtimeProvider';
+import { useAuth } from '../auth/AuthContext';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Table'>;
 
+type Message = { id: string; text: string };
+
 export default function TableScreen({ route, navigation }: Props) {
   const { tableId } = route.params;
+  const { user } = useAuth();
+  const { status, send, subscribe } = useRealtime();
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  const appendMessage = useCallback((text: string) => {
+    setMessages((prev) => [
+      ...prev,
+      { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, text },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    const unsubscribeSystem = subscribe('table:system', (payload) => {
+      if (payload.tableId === tableId) {
+        appendMessage(payload.message);
+      }
+    });
+    const unsubscribeError = subscribe('error', (payload) => {
+      appendMessage(`Error: ${payload.message}`);
+    });
+
+    return () => {
+      unsubscribeSystem();
+      unsubscribeError();
+    };
+  }, [appendMessage, subscribe, tableId]);
+
+  useEffect(() => {
+    if (status === 'open') {
+      send({ type: 'table:join', tableId, displayName: user?.displayName });
+    }
+
+    return () => {
+      if (status === 'open') {
+        send({ type: 'table:leave', tableId });
+      }
+    };
+  }, [send, status, tableId, user?.displayName]);
+
+  const connectionLabel = useMemo(() => {
+    switch (status) {
+      case 'open':
+        return 'Live';
+      case 'connecting':
+        return 'Connecting…';
+      default:
+        return 'Reconnecting…';
+    }
+  }, [status]);
+
   return (
     <View style={s.wrap}>
-      <Text style={s.title}>Table {tableId.toUpperCase()}</Text>
-      <Text style={s.sub}>Video & realtime will appear here</Text>
-      <View style={{ height: 16 }} />
+      <View style={s.header}>
+        <Text style={s.title}>Table {tableId.toUpperCase()}</Text>
+        <Text style={[s.status, status === 'open' ? s.statusOk : s.statusWarn]}>{connectionLabel}</Text>
+      </View>
+      <Text style={s.sub}>Realtime updates</Text>
+      <FlatList
+        data={messages}
+        keyExtractor={(item) => item.id}
+        style={s.feed}
+        contentContainerStyle={messages.length === 0 ? s.feedEmpty : undefined}
+        renderItem={({ item }) => <Text style={s.msg}>{item.text}</Text>}
+        ListEmptyComponent={<Text style={s.emptyText}>Waiting for activity…</Text>}
+      />
       <Pressable style={s.btn} onPress={() => navigation.goBack()}>
         <Text style={s.btnTxt}>Back to Lobby</Text>
       </Pressable>
@@ -20,21 +84,36 @@ export default function TableScreen({ route, navigation }: Props) {
 }
 
 const s = StyleSheet.create({
-  wrap: {
-    flex: 1,
-    backgroundColor: '#0b0f14',
+  wrap: { flex: 1, backgroundColor: '#0b0f14', padding: 24 },
+  header: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24,
+    justifyContent: 'space-between',
   },
   title: { color: 'white', fontSize: 22, fontWeight: '700' },
-  sub: { color: '#9fb3c8', marginTop: 8 },
+  status: { color: '#9fb3c8', fontSize: 13 },
+  statusOk: { color: '#4ce3b4' },
+  statusWarn: { color: '#f0a75e' },
+  sub: { color: '#9fb3c8', marginTop: 8, marginBottom: 12 },
+  feed: {
+    flexGrow: 0,
+    flex: 1,
+    backgroundColor: '#121922',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 16,
+  },
+  feedEmpty: { flex: 1, justifyContent: 'center' },
+  msg: { color: '#e1ecf4', marginBottom: 8 },
+  emptyText: { color: '#9fb3c8', textAlign: 'center' },
   btn: {
     backgroundColor: '#00d6a3',
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 12,
-    marginTop: 16,
+    alignSelf: 'center',
+    marginTop: 8,
   },
   btnTxt: { color: '#001018', fontWeight: '700' },
 });


### PR DESCRIPTION
## Summary
- add a reusable realtime provider that manages a WebSocket connection for the app and wrap the navigation tree with it
- refactor the lobby to consume live table counts and status updates and expand the table screen with realtime message feeds
- replace the socket.io development server with a WebSocket implementation that tracks table membership and broadcasts lobby updates, and document how to run it

## Testing
- npx jest *(fails: react-native-gesture-handler ESM transform issue in the existing Jest setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e4341184388324bc723f66e7bd7a78